### PR TITLE
Always ask for github username

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -78,16 +78,12 @@ module.exports = yeoman.generators.Base.extend({
 
         askForGitHub: function () {
             var done = this.async();
-            var cocoapods = this.cocoapods;
 
             var prompts = [{
                 type: 'input',
                 name: 'githubUser',
                 message: 'Would you mind telling me your username on GitHub?',
                 store: true,
-                when: function () {
-                    return cocoapods;
-                }
             }];
 
             this.prompt(prompts, function (props) {


### PR DESCRIPTION
This PR fixed #5. Now generator-swift-framework will always ask for Github username. While the previous implementation was ask only when distribution with CocoaPods is enabled.
